### PR TITLE
Add manual YouTube title repair

### DIFF
--- a/desktop-app/index.html
+++ b/desktop-app/index.html
@@ -36,6 +36,8 @@
 
         .toolbar {
             display: flex;
+            align-items: center;
+            flex-wrap: wrap;
             gap: 8px;
             margin-bottom: 18px;
         }
@@ -51,6 +53,17 @@
 
         button:hover {
             background: #f3f3f3;
+        }
+
+        button:disabled {
+            cursor: default;
+            opacity: 0.65;
+        }
+
+        .toolbar-status {
+            color: #575757;
+            font-size: 13px;
+            line-height: 1.3;
         }
 
         ul {
@@ -117,6 +130,8 @@
         <p class="hint">Use <strong>Alt+Shift+S</strong> while a player window is focused to save it. Use <strong>Alt+Shift+O</strong> to open this list.</p>
         <div class="toolbar">
             <button id="refresh-btn" type="button">Refresh</button>
+            <button id="fix-youtube-titles-btn" type="button">Fix YouTube Titles</button>
+            <span id="toolbar-status" class="toolbar-status" role="status" aria-live="polite"></span>
         </div>
         <div id="empty-state" class="empty" hidden>No saved videos yet.</div>
         <ul id="watch-later-list"></ul>
@@ -125,6 +140,8 @@
         const listElement = document.getElementById('watch-later-list');
         const emptyStateElement = document.getElementById('empty-state');
         const refreshButton = document.getElementById('refresh-btn');
+        const fixYoutubeTitlesButton = document.getElementById('fix-youtube-titles-btn');
+        const toolbarStatusElement = document.getElementById('toolbar-status');
 
         function buildSavedAtLabel(savedAt) {
             const savedDate = new Date(savedAt);
@@ -210,6 +227,35 @@
 
         refreshButton.addEventListener('click', () => {
             loadWatchLaterList();
+        });
+
+        fixYoutubeTitlesButton.addEventListener('click', async () => {
+            if (!window.watchLater?.backfillYoutubeTitles) {
+                toolbarStatusElement.textContent = 'Title lookup is unavailable.';
+                return;
+            }
+
+            fixYoutubeTitlesButton.disabled = true;
+            toolbarStatusElement.textContent = 'Looking up titles...';
+
+            try {
+                const result = await window.watchLater.backfillYoutubeTitles();
+                await loadWatchLaterList();
+
+                if (!result.checkedCount) {
+                    toolbarStatusElement.textContent = 'No YouTube titles to fix found.';
+                } else if (result.updatedCount === 1) {
+                    toolbarStatusElement.textContent = 'Updated 1 YouTube title.';
+                } else if (result.updatedCount > 1) {
+                    toolbarStatusElement.textContent = `Updated ${result.updatedCount} YouTube titles.`;
+                } else {
+                    toolbarStatusElement.textContent = `Found ${result.checkedCount}, but none could be updated.`;
+                }
+            } catch (error) {
+                toolbarStatusElement.textContent = 'Unable to update YouTube titles.';
+            } finally {
+                fixYoutubeTitlesButton.disabled = false;
+            }
         });
 
         listElement.addEventListener('click', async (event) => {

--- a/desktop-app/main.js
+++ b/desktop-app/main.js
@@ -82,8 +82,38 @@ function isGenericYoutubeTitle(title) {
     return GENERIC_YOUTUBE_TITLES.has((title || '').trim().toLowerCase());
 }
 
-function shouldResolveYoutubeTitle(mediaName, title) {
-    return mediaName === 'youtube' && (!title || isGenericYoutubeTitle(title));
+function isYoutubeVideoUrl(value) {
+    if (!value) return false;
+
+    let parsedUrl;
+    try {
+        parsedUrl = new URL(value);
+    } catch (error) {
+        return false;
+    }
+
+    const hostname = parsedUrl.hostname.replace(/^www\./, '');
+    const isYoutubeHost = hostname === 'youtube.com' ||
+        hostname === 'm.youtube.com' ||
+        hostname === 'youtu.be' ||
+        hostname.endsWith('.youtube.com');
+
+    return isYoutubeHost && Boolean(extractYoutubeMetadata(parsedUrl).videoId);
+}
+
+function getYoutubeTitleLookupUrl(title, sourceUrl) {
+    if (sourceUrl) return sourceUrl;
+    if (isYoutubeVideoUrl(title)) return title;
+    return '';
+}
+
+function shouldResolveYoutubeTitle(mediaName, title, lookupUrl) {
+    if (mediaName !== 'youtube' || !lookupUrl) return false;
+
+    return !title ||
+        isGenericYoutubeTitle(title) ||
+        title === lookupUrl ||
+        isYoutubeVideoUrl(title);
 }
 
 function updateOptionsTitle(options, title) {
@@ -122,8 +152,9 @@ async function buildWatchLaterEntry(mediaName, rawOptions) {
     let title = mediaInfo.title;
     let entryOptions = options;
 
-    if (shouldResolveYoutubeTitle(mediaName, title) && mediaInfo.sourceUrl) {
-        const resolvedTitle = await resolveYoutubeTitle(mediaInfo.sourceUrl);
+    const lookupUrl = getYoutubeTitleLookupUrl(title, mediaInfo.sourceUrl);
+    if (shouldResolveYoutubeTitle(mediaName, title, lookupUrl)) {
+        const resolvedTitle = await resolveYoutubeTitle(lookupUrl);
         if (resolvedTitle) {
             title = resolvedTitle;
             entryOptions = updateOptionsTitle(options, resolvedTitle);
@@ -214,36 +245,42 @@ async function backfillWatchLaterYoutubeTitles() {
 
             const mediaInfo = parseMediaInfoFromOptions(item.options);
             const title = item.title || mediaInfo.title;
+            const lookupUrl = getYoutubeTitleLookupUrl(title, item.sourceUrl || mediaInfo.sourceUrl);
 
-            if (!shouldResolveYoutubeTitle(item.mediaName, title) || !mediaInfo.sourceUrl) {
+            if (!shouldResolveYoutubeTitle(item.mediaName, title, lookupUrl)) {
                 return null;
             }
 
-            return { item, mediaInfo };
+            return { item, mediaInfo, lookupUrl };
         })
         .filter(Boolean);
 
-    const results = await Promise.all(candidates.map(async ({ item, mediaInfo }) => ({
+    const results = await Promise.all(candidates.map(async ({ item, mediaInfo, lookupUrl }) => ({
         item,
         mediaInfo,
-        resolvedTitle: await resolveYoutubeTitle(mediaInfo.sourceUrl)
+        lookupUrl,
+        resolvedTitle: await resolveYoutubeTitle(lookupUrl)
     })));
 
-    let changed = false;
+    let updatedCount = 0;
     results.forEach(({ item, mediaInfo, resolvedTitle }) => {
         if (!resolvedTitle) return;
 
         item.title = resolvedTitle;
         item.options = updateOptionsTitle(item.options, resolvedTitle);
-        item.sourceUrl = item.sourceUrl || mediaInfo.sourceUrl;
-        changed = true;
+        item.sourceUrl = item.sourceUrl || mediaInfo.sourceUrl || lookupUrl;
+        updatedCount += 1;
     });
 
-    if (changed) {
+    if (updatedCount > 0) {
         writeWatchLaterList(items);
     }
 
-    return items;
+    return {
+        checkedCount: candidates.length,
+        updatedCount,
+        failedCount: candidates.length - updatedCount
+    };
 }
 
 function backfillWatchLaterTitlesOnce() {
@@ -332,6 +369,10 @@ function registerWatchLaterIpc() {
     ipcMain.handle('watch-later:list', async () => {
         await backfillWatchLaterTitlesOnce();
         return readWatchLaterList();
+    });
+
+    ipcMain.handle('watch-later:backfill-youtube-titles', () => {
+        return backfillWatchLaterYoutubeTitles();
     });
 
     ipcMain.handle('watch-later:open', (_event, itemId) => {
@@ -441,9 +482,10 @@ function openYoutubePlayer(options) {
 
     const win = createMediaPlayerWindow('youtube', options, config);
     const mediaInfo = parseMediaInfoFromOptions(normalizeOptions(options));
+    const lookupUrl = getYoutubeTitleLookupUrl(mediaInfo.title, mediaInfo.sourceUrl);
 
-    if (shouldResolveYoutubeTitle('youtube', mediaInfo.title) && mediaInfo.sourceUrl) {
-        resolveYoutubeTitle(mediaInfo.sourceUrl).then((resolvedTitle) => {
+    if (shouldResolveYoutubeTitle('youtube', mediaInfo.title, lookupUrl)) {
+        resolveYoutubeTitle(lookupUrl).then((resolvedTitle) => {
             if (!resolvedTitle || win.isDestroyed()) return;
 
             win.setTitle(resolvedTitle);

--- a/desktop-app/preload.js
+++ b/desktop-app/preload.js
@@ -2,6 +2,7 @@ const { contextBridge, ipcRenderer } = require('electron')
 
 contextBridge.exposeInMainWorld('watchLater', {
     list: () => ipcRenderer.invoke('watch-later:list'),
+    backfillYoutubeTitles: () => ipcRenderer.invoke('watch-later:backfill-youtube-titles'),
     open: (id) => ipcRenderer.invoke('watch-later:open', id),
     remove: (id) => ipcRenderer.invoke('watch-later:remove', id),
     saveCurrent: () => ipcRenderer.invoke('watch-later:save-current'),


### PR DESCRIPTION
Adds a Watch Later button next to Refresh that manually finds saved YouTube entries with generic titles or YouTube watch URLs in the title field, then resolves their real titles. The button calls a new IPC handler, refreshes the list after lookup, disables itself while running, and reports how many titles were updated. This gives users an explicit repair action when automatic title backfill does not visibly fix saved entries. Validated with desktop JavaScript syntax checks and the Chrome extension TypeScript check.